### PR TITLE
Codeforces fetcher: Lowercase db handles before comparing rating changes

### DIFF
--- a/fetchers/codeforces.js
+++ b/fetchers/codeforces.js
@@ -32,8 +32,8 @@ let process_final = function(ratings, ev, contest_id) {
 			let msg = 'Ratings for ' + html_msg.make_link(ev.name, ev.url) + ' are out!';
 			let rs = []; // ratings for handles from user
 			user.cf_handles.forEach((h) => {
-				if(mp.has(h))
-					rs.push(mp.get(h));
+				if(mp.has(h.toLowerCase()))
+					rs.push(mp.get(h.toLowerCase()));
 			});
 			if(rs.length === 0)
 				return;


### PR DESCRIPTION
As noted in #33, some users are still ignored because their handles are not lowercased on the db.

This PR lowercases the handles before comparing them to the map of users retrieved from the CF's api.